### PR TITLE
Add Nix package documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ On NixOS or a platform running the Nix package manager, one can install the `git
 nix-shell -p git-credential-email
 ```
 
+(Thanks to [@sephalon](https://github.com/sephalon) for adding support for NixOS!)
+
 ### macOS
 
 [Install Homebrew](https://brew.sh/). Then run the following to add the brew tap and install the helpers:


### PR DESCRIPTION
I have packaged git-credential-email for Nix/NixOS: https://github.com/NixOS/nixpkgs/pull/457641