### PR TITLE
Add PEP 723 inline script metadata

### DIFF
--- a/git-credential-aol
+++ b/git-credential-aol
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+# /// script
+# dependencies = [
+# 	"keyring",
+# 	"requests",
+# ]
+# ///
 #
 # Copyright 2012 Google Inc.
 # Copyright 2025 Aditya Garg

--- a/git-credential-gmail
+++ b/git-credential-gmail
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+# /// script
+# dependencies = [
+# 	"keyring",
+# 	"requests",
+# ]
+# ///
 #
 # Copyright 2012 Google Inc.
 # Copyright 2025 Aditya Garg

--- a/git-credential-outlook
+++ b/git-credential-outlook
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+# /// script
+# dependencies = [
+# 	"keyring",
+# 	"requests",
+# ]
+# ///
 #
 # Copyright 2012 Google Inc.
 # Copyright 2025 Aditya Garg

--- a/git-credential-yahoo
+++ b/git-credential-yahoo
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+# /// script
+# dependencies = [
+# 	"keyring",
+# 	"requests",
+# ]
+# ///
 #
 # Copyright 2012 Google Inc.
 # Copyright 2025 Aditya Garg

--- a/git-msgraph
+++ b/git-msgraph
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+# /// script
+# dependencies = [
+# 	"keyring",
+# 	"requests",
+# ]
+# ///
 #
 # Copyright 2012 Google Inc.
 # Copyright 2025 Aditya Garg

--- a/git-protonmail
+++ b/git-protonmail
@@ -1,4 +1,15 @@
 #!/usr/bin/env python3
+# /// script
+# dependencies = [
+# 	"bcrypt",
+# 	"cryptography",
+# 	"keyring",
+# 	"pgpy13",
+# 	"requests",
+# 	"requests-toolbelt",
+# 	"typing-extensions",
+# ]
+# ///
 #
 # Copyright 2025 Aditya Garg
 #


### PR DESCRIPTION
This adds [PEP 723](https://peps.python.org/pep-0723/) inline script metadata to each helper, declaring its Python dependencies in a comment block that tools like uv and pipx understand.

With this, a helper can be run directly from a checkout (or a raw file download) with its dependencies resolved automatically into a cached ephemeral environment, nothing installed system-wide and no pip step:

```
uv run --script ./git-credential-gmail --authenticate --external-auth
```

(`--script` tells uv to treat the extensionless file as a Python script.)

The helpers can also be run directly from a URL, with no checkout:

```
uv run https://raw.githubusercontent.com/AdityaGarg8/git-credential-email/<commit-sha>/git-credential-gmail --authenticate --external-auth
```

(No `--script` needed for URLs. Pinning a commit SHA rather than `main` keeps the executed content fixed.)

And git can invoke a helper the same way:

```
[credential "smtp://smtp.gmail.com:465"]
	helper = "!uv run --quiet --script /path/to/git-credential-gmail"
```

Notes:

- Comment-only change: nothing changes for existing installs, distro packages, or plain `python3` invocations. Tools that don't know PEP 723 ignore the block.
- The optional PyQt6/PySide6 browser dependencies are deliberately not declared; the scripts already handle their absence gracefully, and `--external-auth` works out of the box this way.
- `git-protonmail` declares `pgpy13` rather than `pgpy`, since upstream PGPy fails on Python 3.13 and you recommended the fork in #16. It provides the same `pgpy` module.
- Tested all six helpers with `uv run --script <helper> --help` on Linux (uv 0.12.5); each resolves its environment and runs.